### PR TITLE
Fix broken test cases.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ One of the best ways to support us is by sharing your experience with Klarity! W
 can run `pip install -e ".[dev]"`
 4. Create a new branch for your feature: `git checkout -b feature/amazing-feature`
 5. Make your changes
-6. Run tests: via `uv pytest` or `python -m pytest tests/`
+6. Run tests: via `uv run pytest` or `python -m pytest tests/`
 7. Lint and clean your code using 
 ```
 uv tool install ruff (one time only)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ can run `pip install -e ".[dev]"`
 uv tool install ruff (one time only)
 uvx ruff check 
 uvx ruff clean
+uvx ruff format
 ```
 8. Submit a PR with a clear description of your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,12 @@ One of the best ways to support us is by sharing your experience with Klarity! W
 ## Making Contributions ❤️
 
 1. Fork the repository
-2. We use uv as our python project manager. To learn how to install uv visit [here](https://docs.astral.sh/uv/getting-started/)
-3. Install dependencies by running `uv pip install -r pyproject.toml`
+2. We use uv as our python project manager. To learn how to install uv visit [here](https://docs.astral.sh/uv/getting-started/). After downloading uv create a .venv using `uv venv`
+3. Install dependencies by running `uv pip install -r pyproject.toml`. Alternatively if you don't want to use uv you
+can run `pip install -e ".[dev]"`
 4. Create a new branch for your feature: `git checkout -b feature/amazing-feature`
 5. Make your changes
-6. Run tests: `python -m pytest tests/`
+6. Run tests: via `uv pytest` or `python -m pytest tests/`
 7. Lint and clean your code using 
 ```
 uv tool install ruff (one time only)

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -11,9 +11,7 @@ tokenizer = AutoTokenizer.from_pretrained(model_name)
 # Create estimator
 estimator = UncertaintyEstimator(
     top_k=100,
-    analyzer=EntropyAnalyzer(
-        min_token_prob=0.01, insight_model=model, insight_tokenizer=tokenizer
-    ),
+    analyzer=EntropyAnalyzer(min_token_prob=0.01, insight_model=model, insight_tokenizer=tokenizer),
 )
 
 uncertainty_processor = estimator.get_logits_processor()
@@ -34,13 +32,9 @@ generation_output = model.generate(
 )
 
 # Analyze the generation
-result = estimator.analyze_generation(
-    generation_output, tokenizer, uncertainty_processor
-)
+result = estimator.analyze_generation(generation_output, tokenizer, uncertainty_processor)
 
-generated_text = tokenizer.decode(
-    generation_output.sequences[0], skip_special_tokens=True
-)
+generated_text = tokenizer.decode(generation_output.sequences[0], skip_special_tokens=True)
 
 # Inspect results
 print(f"\nPrompt: {prompt}")

--- a/examples/basic_usage_hosted_insights.py
+++ b/examples/basic_usage_hosted_insights.py
@@ -35,14 +35,10 @@ generation_output = model.generate(
 )
 
 # Analyze the generation
-result = estimator.analyze_generation(
-    generation_output, tokenizer, uncertainty_processor
-)
+result = estimator.analyze_generation(generation_output, tokenizer, uncertainty_processor)
 
 # Get generated text
-generated_text = tokenizer.decode(
-    generation_output.sequences[0], skip_special_tokens=True
-)
+generated_text = tokenizer.decode(generation_output.sequences[0], skip_special_tokens=True)
 print(f"\nPrompt: {prompt}")
 print(f"Generated text: {generated_text}")
 

--- a/examples/basic_usage_reasoning.py
+++ b/examples/basic_usage_reasoning.py
@@ -48,9 +48,7 @@ result = estimator.analyze_generation(
 )
 
 # Get generated text
-generated_text = tokenizer.decode(
-    generation_output.sequences[0], skip_special_tokens=True
-)
+generated_text = tokenizer.decode(generation_output.sequences[0], skip_special_tokens=True)
 print(f"\nPrompt: {prompt}")
 print(f"Generated text: {generated_text}")
 

--- a/examples/basic_usage_together_ai.py
+++ b/examples/basic_usage_together_ai.py
@@ -16,9 +16,7 @@ estimator = UncertaintyEstimator(
 
 # Generate and analyze
 prompt = "Your prompt"
-generation_output = estimator._generate_with_together(
-    prompt=prompt, max_new_tokens=10, temperature=0.7
-)
+generation_output = estimator._generate_with_together(prompt=prompt, max_new_tokens=10, temperature=0.7)
 
 result = estimator.analyze_generation(generation_output)
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,8 +1,8 @@
 # work in progress
 import pytest
 import numpy as np
-from klarity.core.analyzer import EntropyAnalyzer
-from klarity.models import TokenInfo, UncertaintyAnalysisRequest
+from src.klarity.core.analyzer import EntropyAnalyzer
+from src.klarity.models import TokenInfo, UncertaintyAnalysisRequest
 
 
 @pytest.fixture
@@ -78,9 +78,7 @@ def test_calculate_group_probabilities(analyzer, sample_token_info):
 
 
 def test_analyze_empty_request(analyzer):
-    empty_request = UncertaintyAnalysisRequest(
-        logits=[], prompt="", model_id="test", token_info=[]
-    )
+    empty_request = UncertaintyAnalysisRequest(logits=[], prompt="", model_id="test", token_info=[])
     metrics = analyzer.analyze(empty_request)
     assert metrics.raw_entropy == 0.0
     assert metrics.semantic_entropy == 0.0
@@ -88,9 +86,7 @@ def test_analyze_empty_request(analyzer):
 
 def test_analyze_single_token(analyzer):
     single_token = [TokenInfo(token="test", token_id=0, logit=0.0, probability=1.0)]
-    request = UncertaintyAnalysisRequest(
-        logits=[0.0], prompt="test", model_id="test", token_info=single_token
-    )
+    request = UncertaintyAnalysisRequest(logits=[0.0], prompt="test", model_id="test", token_info=single_token)
     metrics = analyzer.analyze(request)
     assert metrics.raw_entropy == 0.0  # Single token should have zero entropy
     assert metrics.semantic_entropy == 0.0

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,8 +1,8 @@
 # work in progress
 import pytest
 import numpy as np
-from src.klarity.core.analyzer import EntropyAnalyzer
-from src.klarity.models import TokenInfo, UncertaintyAnalysisRequest
+from klarity.core.analyzer import EntropyAnalyzer
+from klarity.models import TokenInfo, UncertaintyAnalysisRequest
 
 
 @pytest.fixture

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -1,8 +1,8 @@
 # work in progess
 import pytest
 import torch
-from src.klarity.estimator import UncertaintyEstimator, UncertaintyLogitsProcessor
-from src.klarity.core.analyzer import EntropyAnalyzer
+from klarity.estimator import UncertaintyEstimator, UncertaintyLogitsProcessor
+from klarity.core.analyzer import EntropyAnalyzer
 
 
 class MockTokenizer:

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -1,12 +1,12 @@
 # work in progess
 import pytest
 import torch
-from klarity.estimator import UncertaintyEstimator, UncertaintyLogitsProcessor
-from klarity.core.analyzer import EntropyAnalyzer
+from src.klarity.estimator import UncertaintyEstimator, UncertaintyLogitsProcessor
+from src.klarity.core.analyzer import EntropyAnalyzer
 
 
 class MockTokenizer:
-    def decode(self, token_id):
+    def decode(self, token_id, **kwargs):
         return f"token_{token_id}"
 
 
@@ -41,13 +41,9 @@ def sample_generation_output():
 
 
 def test_init():
-    estimator = UncertaintyEstimator(
-        top_k=100, analyzer=EntropyAnalyzer(min_token_prob=0.02)
-    )
+    estimator = UncertaintyEstimator(top_k=100, analyzer=EntropyAnalyzer(min_token_prob=0.02))
     assert estimator.top_k == 100, "top_k should be 100"
-    assert isinstance(estimator.analyzer, EntropyAnalyzer), (
-        "analyzer should be an instance of EntropyAnalyzer"
-    )
+    assert isinstance(estimator.analyzer, EntropyAnalyzer), "analyzer should be an instance of EntropyAnalyzer"
 
     custom_analyzer = EntropyAnalyzer(min_token_prob=0.02)
     estimator = UncertaintyEstimator(top_k=50, analyzer=custom_analyzer)
@@ -83,9 +79,7 @@ def test_process_logits(
     assert 0.99 <= total_prob <= 1.01
 
 
-def test_analyze_generation(
-    estimator, mock_tokenizer, sample_generation_output, logits_processor
-):
+def test_analyze_generation(estimator, mock_tokenizer, sample_generation_output, logits_processor):
     # Add some sample logits
     logits_processor.captured_logits.append(torch.randn(1, 5))
     logits_processor.captured_logits.append(torch.randn(1, 5))
@@ -101,9 +95,7 @@ def test_analyze_generation(
         assert len(metrics.token_predictions) == estimator.top_k
 
 
-def test_empty_generation(
-    estimator, mock_tokenizer, sample_generation_output, logits_processor
-):
+def test_empty_generation(estimator, mock_tokenizer, sample_generation_output, logits_processor):
     metrics_list = estimator.analyze_generation(
         sample_generation_output, mock_tokenizer, logits_processor
     ).token_metrics


### PR DESCRIPTION
## Summary

#3 introduced a bug causing a couple of test cases to fail because of the `MockDecoder` not having an argument to accept the boolean `skip_special_tokens`.

This PR fixes the failing test cases by verifying all the test cases execute by running

1. `uv run pytest`

The PR also re-formats some code using the command `uvx ruff format`.

Updated the contributing.md to reflect some of these best practices.