### PR TITLE
Use MinishLab's static emebddings for semantic entropy.

### DIFF
--- a/src/klarity/core/analyzer.py
+++ b/src/klarity/core/analyzer.py
@@ -41,7 +41,7 @@ class EntropyAnalyzer:
         insight_prompt_template: Optional[str] = None,
         insight_response_model: BaseModel = InsightAnalysisResponseModel,
     ):
-        self.embedding_model = SentenceTransformer("all-MiniLM-L6-v2")
+        self.embedding_model = SentenceTransformer("minishlab/potion-base-8M")
         self.min_token_prob = min_token_prob
 
         # Initialize Together AI model if specified


### PR DESCRIPTION
##Summary

Addresses #5 and leverages static embeddings from MinishLabs to compute semantic entropy as the default embedding model. As a reminder this works best only when semantic entropy is computed at the token level and not at the sentence/document level.