### PR TITLE
refactor: Refactor release workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,4 +1,4 @@
-name: Upload Python Package
+name: Release to PyPI
 
 on:
   release:
@@ -8,69 +8,15 @@ permissions:
   contents: read
 
 jobs:
-  release-build:
+  pypi:
+    name: Publish to PyPI
     runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-
-      # Added debugging steps
-      - name: Debug directory structure
-        run: |
-          echo "Current directory:"
-          pwd
-          echo "Directory contents:"
-          ls -R
-          echo "Python version:"
-          python --version
-          
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install build wheel setuptools
-
-      - name: Build release distributions
-        run: |
-          python -m build
-        
-      - name: Check built distributions
-        run: |
-          echo "Distribution contents:"
-          ls -l dist/
-
-      - name: Upload distributions
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-dists
-          path: dist/
-
-  pypi-publish:
-    runs-on: ubuntu-latest
-    needs:
-      - release-build
-    permissions:
-      id-token: write
-
     environment:
       name: pypi
-
+    permissions:
+      id-token: write
     steps:
-      - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
-        with:
-          name: release-dists
-          path: dist/
-
-      - name: Verify retrieved distributions
-        run: |
-          echo "Retrieved distribution contents:"
-          ls -l dist/
-
-      - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv build
+      - run: uv publish --trusted-publishing always

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["setuptools>=45", "wheel"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "klarity"
 version = "0.1.0"
@@ -24,6 +20,11 @@ dependencies = [
 Homepage = "https://github.com/klara-research/klarity"
 Issues = "https://github.com/klara-research/klarity/issues"
 Repository = "https://github.com/klara-research/klarity.git"
+
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
 
 [tool.setuptools]
 package-dir = {"" = "src"}


### PR DESCRIPTION
# Streamlined PyPI Release Workflow

## What has been done

- **Simplified PyPI release workflow** using uv build and publish
  - Replaced the previous two-job workflow with a single job
  - Switched from using setuptools/build to uv for more efficient builds
  - Eliminated the need for intermediate artifact storage and retrieval
  - Adopted trusted publishing with PyPI for enhanced security

- **Reorganized pyproject.toml build system configuration**
  - Moved build-system section after project metadata for better readability
  - Maintained the same build dependencies (setuptools and wheel)

- **Renamed GitHub Actions workflow** from "Upload Python Package" to "Release to PyPI" for clarity

## Potential issues

- **Environment configuration**: The workflow currently specifies ‘pypi' as the environment name (kept from the previous action). This will need to be configured in the GitHub repository settings with the appropriate PyPI publishing credentials.

## Testing

This workflow will only trigger when a new release is published, so it can be safely merged and tested with the next release.

## Additional notes

The new workflow uses [uv](https://github.com/astral-sh/uv), which should make the build and publish process more efficient. This replaces the previous multi-step process that used setuptools and the PyPA GitHub Action.